### PR TITLE
Check that returned underlyingPriceis not zero

### DIFF
--- a/src/mappings/markets.ts
+++ b/src/mappings/markets.ts
@@ -45,10 +45,11 @@ function getTokenPrice(
   let mantissaDecimalFactor = 18 - underlyingDecimals + 18
   let bdFactor = exponentToBigDecimal(mantissaDecimalFactor)
   let oracle2 = PriceOracle2.bind(oracleAddress)
-  underlyingPrice = oracle2
-    .getUnderlyingPrice(eventAddress)
-    .toBigDecimal()
-    .div(bdFactor)
+  const oracleUnderlyingPrice = oracle2.getUnderlyingPrice(eventAddress).toBigDecimal()
+  if (oracleUnderlyingPrice.equals(BigDecimal.zero())) {
+    return oracleUnderlyingPrice
+  }
+  underlyingPrice = oracleUnderlyingPrice.div(bdFactor)
 
   return underlyingPrice
 }
@@ -159,7 +160,10 @@ export function updateMarket(
         Address.fromBytes(market.underlyingAddress),
         market.underlyingDecimals,
       )
-      if (bnbPriceInUSD.equals(BigDecimal.zero())) {
+      if (
+        bnbPriceInUSD.equals(BigDecimal.zero()) ||
+        tokenPriceUSD.equals(BigDecimal.zero())
+      ) {
         market.underlyingPrice = BigDecimal.zero()
       } else {
         market.underlyingPrice = tokenPriceUSD


### PR DESCRIPTION
When price feeds were to set to zero to disable the protocol during the Lune UST incident the subgraph failed because it tried to divide by zero.

This PR adds additional price checks to prevent this indexing error in the future